### PR TITLE
Feature/global view improvements and locks

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -45,6 +45,9 @@ def handle_client_message():
 @cross_origin()
 def get_modules_data():
     """Returns current values of variables in the modules."""
+    test_name = os.getenv("INTEGRATION_TEST")
+    test_data = {"test_name": test_name} if test_name else None
+
     data = {"VIEW_ESTABLISHMENT_MODULE":
             app.resolver.get_view_establishment_data(),
             "REPLICATION_MODULE":
@@ -52,7 +55,7 @@ def get_modules_data():
             "PRIMARY_MONITORING_MODULE":
             app.resolver.get_primary_monitoring_data(),
             "node_id": int(os.getenv("ID")),
-            "test_data": {"test_name": os.getenv("INTEGRATION_TEST")},
+            "test_data": test_data,
             "byzantine": byz.is_byzantine(),
             "byzantine_behavior": byz.get_byz_behavior()
             }

--- a/api/templates/view/head.html
+++ b/api/templates/view/head.html
@@ -5,6 +5,7 @@
     <style>
         :root {
             --blue: #326273;
+            --red: #c42f2f;
             --white: white;
             --light: #EEEEEE;
             --node-side: 300px;
@@ -27,6 +28,10 @@
             font-size: 1.25em;
         }
 
+        #test-data {
+            margin-top: 20px;
+        }
+
         .nodes-container {
             display: flex;
             flex-wrap: wrap;
@@ -42,7 +47,7 @@
             width: var(--node-side);
             height: var(--node-side);
             margin: auto;
-            background: var(--blue);
+            background-color: var(--blue);
             color: var(--white);
             border-radius: 50%;
             display: flex;
@@ -52,9 +57,16 @@
             text-align: center;
         }
 
+        .node.byzantine {
+            background-color: var(--red)
+        }
+
         .node > p:first-child { font-size: 1.5em; }
         p { margin: 0; }
-        .node span { opacity: 0; margin-top: 10px; }
+        .node span {
+            margin-top: 10px;
+            font-size: 1.3em;
+        }
 
         .data {
             font-size: 1.2em;

--- a/api/templates/view/main.html
+++ b/api/templates/view/main.html
@@ -4,16 +4,25 @@
 <body>
     <h1>BFTList global view</h1>
     <p>Another day, another algorithm</p>
-    <button id="refreshButton">Refresh view</button>
+
+    <!-- hide refresh button for now, not needed -->
+    <!--<button id="refreshButton">Refresh view</button> -->
+
+    {% if data.test_data %}
+    <div id="test-info">
+        <h3 id="test-name">{{ data.test_data.test_name }}</h3>
+    </div>
+    {% endif %}
 
     <div class="nodes-container">
-    {% for item in data %}
+    {% for item in data.nodes_data %}
         <div class="node-wrapper">
-            <div class="node">
+            <div class="node" id="node-{{ item.node.id }}">
                 <p>Node {{ item.node.id }}</p>
                 <p>Hostname {{ item.node.hostname }}</p>
                 <p>IP:port {{ item.node.ip }}:{{ item.node.port }}</p></p>
-                <span id=refreshLabel{{ item.node.id }}>Refreshing node data..</span>
+                <span id="byz-behavior-{{ item.node.id }}"></span>
+                
             </div>
             
             <div class="data" id="data-node-{{ item.node.id }}">

--- a/api/templates/view/scripts.html
+++ b/api/templates/view/scripts.html
@@ -1,12 +1,34 @@
 <script>
-    const nodes = JSON.parse('{{ data | tojson }}').map(el => el.node)
-    const strongify = s => `<b><u>${s}</u></b>`
+    const BYZ_CLASSNAME = 'byzantine'
 
+    nodeElements = {}
+    const nodes = JSON.parse('{{ data.nodes_data | tojson }}').map(el => {
+        // pre-get all dom nodes on mount, this won't change
+        id = el.data.node_id
+        nodeElements[id] = {
+            node: document.getElementById(`node-${id}`),
+            data: document.getElementById(`data-node-${id}`),
+            byzBehaviorSpan: document.getElementById(`byz-behavior-${id}`)
+        }
+        return el.node
+    })
     const defaultFetchInterval = 100
+    const testName = document.getElementById('test-name')
     let interval, fetchInterval = defaultFetchInterval
 
+    const strongify = s => `<b><u>${s}</u></b>`
+
+    const renderByzantineNode = (id, behavior) => {
+        nodeElements[id].node.classList.add(BYZ_CLASSNAME)
+        nodeElements[id].byzBehaviorSpan.innerHTML = behavior
+    }
+
+    const renderNormalNode = (id) => {
+        nodeElements[id].node.classList.remove(BYZ_CLASSNAME)
+        nodeElements[id].byzBehaviorSpan.innerHTML = ''
+    }
+
     const renderViewEstData = (id, data) => {
-        const dataNode = document.getElementById(`data-node-${id}`)
         let phases = 'Phases: ', views = 'Views: ', witnesses = 'Witnesses: '
 
         // build phases string
@@ -25,11 +47,11 @@
         })
 
         vChange = data.vChange ? 'True' : 'False'
-
-        dataNode.children[0].innerHTML = phases
-        dataNode.children[1].innerHTML = views
-        dataNode.children[2].innerHTML = `vChange: ${vChange}`
-        dataNode.children[3].innerHTML = witnesses
+        
+        nodeElements[id].data.children[0].innerHTML = phases
+        nodeElements[id].data.children[1].innerHTML = views
+        nodeElements[id].data.children[2].innerHTML = `vChange: ${vChange}`
+        nodeElements[id].data.children[3].innerHTML = witnesses
     }
 
     const renderRepData = (id, data) => {}
@@ -41,9 +63,14 @@
             fetch(`http://${n.ip}:400${n.id}/data`)
                 .then(res => res.json())
                 .then(res => {
+                    res.byzantine
+                        ? renderByzantineNode(res.node_id, res.byzantine_behavior)
+                        : renderNormalNode(res.node_id)
                     renderViewEstData(res.node_id, res.VIEW_ESTABLISHMENT_MODULE)
                     renderRepData(res.node_id, res.REPLICATION_MODULE)
                     renderPriMonData(res.node_id, res.PRIMARY_MONITORING_MODULE)
+
+                    testName.innerHTML = res.test_data.test_name || 'unknown test'
 
                     // back to full speed if speed was throttled
                     if (fetchInterval > defaultFetchInterval) {
@@ -55,7 +82,7 @@
                     console.error(err)
                     // new slower fetch interval when node is down
                     clearInterval(interval)
-                    fetchInterval = 3000
+                    fetchInterval = defaultFetchInterval * 10
                     interval = setInterval(refreshNodes, fetchInterval)
                 })
         })
@@ -64,7 +91,7 @@
     // register listeners and handlers
     const onLoad = () => {
         interval = setInterval(refreshNodes, defaultFetchInterval)
-        document.getElementById("refreshButton").onclick = refreshNodes
+        // document.getElementById("refreshButton").onclick = refreshNodes
     }
     window.onload = onLoad;
 </script>

--- a/api/templates/view/scripts.html
+++ b/api/templates/view/scripts.html
@@ -1,10 +1,13 @@
 <script>
     const BYZ_CLASSNAME = 'byzantine'
 
-    nodeElements = {}
+    let nodeElements = {}
+    let fetchIntervals = [], failedReqs = []
     const nodes = JSON.parse('{{ data.nodes_data | tojson }}').map(el => {
         // pre-get all dom nodes on mount, this won't change
         id = el.data.node_id
+        fetchIntervals[id] = null
+        failedReqs[id] = 0
         nodeElements[id] = {
             node: document.getElementById(`node-${id}`),
             data: document.getElementById(`data-node-${id}`),
@@ -13,8 +16,8 @@
         return el.node
     })
     const defaultFetchInterval = 100
-    const testName = document.getElementById('test-name')
-    let interval, fetchInterval = defaultFetchInterval
+    let fetchInterval = defaultFetchInterval
+    let testName = document.getElementById('test-name')
 
     const strongify = s => `<b><u>${s}</u></b>`
 
@@ -57,41 +60,53 @@
     const renderRepData = (id, data) => {}
     const renderPriMonData = (id, data) => {}
 
-    // fetches data for all nodes and updates the view
-    const refreshNodes = () => {
-        nodes.forEach(n => {
-            fetch(`http://${n.ip}:400${n.id}/data`)
-                .then(res => res.json())
-                .then(res => {
-                    res.byzantine
-                        ? renderByzantineNode(res.node_id, res.byzantine_behavior)
-                        : renderNormalNode(res.node_id)
-                    renderViewEstData(res.node_id, res.VIEW_ESTABLISHMENT_MODULE)
-                    renderRepData(res.node_id, res.REPLICATION_MODULE)
-                    renderPriMonData(res.node_id, res.PRIMARY_MONITORING_MODULE)
+    // fetches data for a nodes and updates its view
+    const refreshNode = n => {
+        fetch(`http://${n.ip}:400${n.id}/data`)
+            .then(res => res.json())
+            .then(res => {
+                failedReqs[n.id] = 0
+                res.byzantine
+                    ? renderByzantineNode(res.node_id, res.byzantine_behavior)
+                    : renderNormalNode(res.node_id)
+                renderViewEstData(res.node_id, res.VIEW_ESTABLISHMENT_MODULE)
+                renderRepData(res.node_id, res.REPLICATION_MODULE)
+                renderPriMonData(res.node_id, res.PRIMARY_MONITORING_MODULE)
 
+                if (res.test_data) {
+                    // testName might not have been rendered on mount
+                    if (!testName) testName = document.getElementById('test-name')
                     testName.innerHTML = res.test_data.test_name || 'unknown test'
+                }
 
-                    // back to full speed if speed was throttled
-                    if (fetchInterval > defaultFetchInterval) {
-                        fetchInterval = defaultFetchInterval
-                        interval = setInterval(refreshNodes, fetchInterval)
-                    }
-                })
-                .catch(err => {
-                    console.error(err)
-                    // new slower fetch interval when node is down
-                    clearInterval(interval)
-                    fetchInterval = defaultFetchInterval * 10
-                    interval = setInterval(refreshNodes, fetchInterval)
-                })
-        })
+                // back to full speed if speed was throttled
+                if (fetchInterval > defaultFetchInterval) {
+                    fetchInterval = defaultFetchInterval
+                    clearInterval(fetchIntervals[n.id])
+                    fetchIntervals[n.id] = setInterval(() => refreshNode(n), fetchInterval)
+                }
+            })
+            .catch(err => {
+                console.error(err)
+                failedReqs[n.id]++
+                clearInterval(fetchIntervals[n.id])
+
+                // increase fetch time to 2s when node is non-responsive
+                if (failedReqs[n.id] < 5) {
+                    fetchInterval = 2000
+                    fetchIntervals[n.id] = setInterval(() => refreshNode(n), fetchInterval)
+                } else {
+                    console.log(`Node ${n.id} has not been responding for ${failedReqs[n.id]} requests, won't try again`)
+                }
+
+            })
     }
 
     // register listeners and handlers
     const onLoad = () => {
-        interval = setInterval(refreshNodes, defaultFetchInterval)
-        // document.getElementById("refreshButton").onclick = refreshNodes
+        nodes.forEach(n => {
+            fetchIntervals[n.id] = setInterval(() => refreshNode(n), defaultFetchInterval)
+        })
     }
     window.onload = onLoad;
 </script>

--- a/communication/recv.py
+++ b/communication/recv.py
@@ -84,7 +84,10 @@ class Receiver():
         try:
             msg_json = self.pack_helper.unpack(payload)[0][0]
             msg = json.loads(msg_json.decode())
-            self.resolver.dispatch_msg(msg, sender)
+
+            # dispatch message to correct module through resolver
+            self.resolver.dispatch_msg(msg)
+
             logger.debug(f"Received msg {msg} from node {sender}")
         except struct.error:
             logger.debug(f"Error: Could not unpack {payload}")

--- a/modules/byzantine.py
+++ b/modules/byzantine.py
@@ -18,6 +18,6 @@ def is_byzantine():
 def get_byz_behavior():
     """Returns the configured Byzantine behavior for this node."""
     behavior = os.getenv("BYZANTINE_BEHAVIOR")
-    if behavior is None or behavior not in BYZ_BEHAVIORS:
+    if is_byzantine() and (behavior is None or behavior not in BYZ_BEHAVIORS):
         logger.error("Node not configured correctly for Byzantine behavior")
     return behavior

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -44,6 +44,7 @@ class ReplicationModule(AlgorithmModule):
         """Initializes the module."""
         self.id = id
         self.resolver = resolver
+        self.lock = resolver.replication_lock
         self.number_of_nodes = n
         self.number_of_byzantine = f
         self.number_of_clients = k
@@ -76,6 +77,7 @@ class ReplicationModule(AlgorithmModule):
         """Called whenever the module is launched in a separate thread."""
         while True:
             # lines 1-3
+            self.lock.acquire()
             if (not self.rep[self.id][VIEW_CHANGE] and
                     self.resolver.execute(Module.VIEW_ESTABLISHMENT_MODULE,
                                           Function.ALLOW_SERVICE)):
@@ -208,7 +210,7 @@ class ReplicationModule(AlgorithmModule):
                                 (req_status[REQUEST][SEQUENCE_NO] ==
                                     self.last_exec() + 1)):
                             self.commit({REQUEST: req_status, X_SET: x_set})
-
+            self.lock.release()
             self.send_msg()
             time.sleep(0.1 if os.getenv("INTEGRATION_TEST") else 0.25)
 

--- a/modules/view_establishment/module.py
+++ b/modules/view_establishment/module.py
@@ -27,6 +27,7 @@ class ViewEstablishmentModule(AlgorithmModule):
     def __init__(self, id, resolver, n, f):
         """Initializes the module."""
         self.resolver = resolver
+        self.lock = resolver.view_est_lock
         self.phs = [0 for i in range(n)]
         self.witnesses = [False for i in range(n)]
         self.pred_and_action = PredicatesAndAction(self, id, self.resolver,
@@ -61,7 +62,7 @@ class ViewEstablishmentModule(AlgorithmModule):
     def run(self):
         """Called whenever the module is launched in a separate thread."""
         while True:
-            self.resolver.lock.acquire()
+            self.lock.acquire()
             if(self.pred_and_action.need_reset()):
                 self.pred_and_action.reset_all()
             self.witnesses[self.id] = self.noticed_recent_value()
@@ -85,7 +86,7 @@ class ViewEstablishmentModule(AlgorithmModule):
                     self.pred_and_action.automation(
                         ViewEstablishmentEnums.ACTION, self.phs[self.id], case)
 
-            self.resolver.lock.release()
+            self.lock.release()
             # Send message to all other processors
             self.send_msg()
             time.sleep(0.1 if os.getenv("INTEGRATION_TEST") else 0.25)

--- a/tests/integration_tests/helpers.py
+++ b/tests/integration_tests/helpers.py
@@ -50,7 +50,7 @@ async def GET(node_id, path):
 
 
 # application runner helpers
-async def launch_bftlist(args={}):
+async def launch_bftlist(test_name="unknown test", args={}):
     """Launches BFTList for integration testing."""
     nodes = get_nodes()
     cmd = "source env/bin/activate && python3.7 main.py"
@@ -65,7 +65,7 @@ async def launch_bftlist(args={}):
         env["NUMBER_OF_BYZANTINE"] = str(F)
         env["NUMBER_OF_CLIENTS"] = "1"
         env["HOSTS_PATH"] = os.path.abspath(RELATIVE_PATH_FIXTURES_HOST)
-        env["INTEGRATION_TEST"] = "true"
+        env["INTEGRATION_TEST"] = test_name
 
         if "BYZANTINE" in args:
             if node_id in args["BYZANTINE"]["NODES"]:

--- a/tests/integration_tests/test_health.py
+++ b/tests/integration_tests/test_health.py
@@ -17,7 +17,7 @@ class TestHealth(AbstractIntegrationTest):
 
     async def bootstrap(self):
         """Sets up BFTList for the test."""
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         """Validates response from / endpoint on all nodes

--- a/tests/integration_tests/test_node_follow_to_phase_0.py
+++ b/tests/integration_tests/test_node_follow_to_phase_0.py
@@ -48,7 +48,7 @@ class TestNodesFollow(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_node_follows_to_view_transition.py
+++ b/tests/integration_tests/test_node_follows_to_view_transition.py
@@ -52,7 +52,7 @@ class TestNodesFollow(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_node_starts_in_reset_and_converges.py
+++ b/tests/integration_tests/test_node_starts_in_reset_and_converges.py
@@ -38,7 +38,7 @@ class TestNodeConvergeAfterReset(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_nodes_cannot_progress_with_silent_nodes.py
+++ b/tests/integration_tests/test_nodes_cannot_progress_with_silent_nodes.py
@@ -56,7 +56,7 @@ class TestNodesConvergeThroughResetAll(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist(args)
+        return await helpers.launch_bftlist(__name__, args)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_nodes_converge_through_reset_all.py
+++ b/tests/integration_tests/test_nodes_converge_through_reset_all.py
@@ -41,7 +41,7 @@ class TestNodesConvergeThroughResetAll(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_nodes_move_to_view_upon_view_change.py
+++ b/tests/integration_tests/test_nodes_move_to_view_upon_view_change.py
@@ -39,7 +39,7 @@ class TestNodeMovesToViewOnViewChange(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_nodes_reset_upon_stale_info.py
+++ b/tests/integration_tests/test_nodes_reset_upon_stale_info.py
@@ -42,7 +42,7 @@ class TestNodesConvergeThroughResetAll(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS

--- a/tests/integration_tests/test_two_nodes_behind_and_follow.py
+++ b/tests/integration_tests/test_two_nodes_behind_and_follow.py
@@ -55,7 +55,7 @@ class TestNodesFollow(AbstractIntegrationTest):
     async def bootstrap(self):
         """Sets up BFTList for the test."""
         helpers.write_state_conf_file(start_state)
-        return await helpers.launch_bftlist()
+        return await helpers.launch_bftlist(__name__)
 
     async def validate(self):
         calls_left = helpers.MAX_NODE_CALLS


### PR DESCRIPTION
* Global view updated with name of running test and indication of what nodes are byzantine and what they're doing

* Two locks instead of one in resolver, where modules acquire their respective lock through their resolver instance in the while true loop. No lock added for PM module yet, will add later in same fashion if needed.