### PR TITLE
Feature/node sleep it

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -1,9 +1,16 @@
 """Server that provides the BFTList API."""
 
+# standard
 from flask import Flask
-from api.routes import routes
 from flask_cors import CORS
 import os
+import logging
+
+# local
+from api.routes import routes
+
+# global
+logger = logging.getLogger(__name__)
 
 
 def create_app(resolver):
@@ -16,7 +23,8 @@ def create_app(resolver):
 
 
 def start_server(resolver):
-    """Foo bar baz."""
+    """Starts the Flask server."""
     app = create_app(resolver)
     port = int(os.getenv("API_PORT", 4000))
+    logger.info(f"Starting the FLASK server on port {port}")
     app.run(port=port)

--- a/main.py
+++ b/main.py
@@ -120,4 +120,5 @@ if __name__ == "__main__":
     setup_metrics()
     start_modules(resolver)
     start_api(resolver)
+    # always run last, due to asyncio loop run_forever
     setup_communication(resolver)

--- a/modules/primary_monitoring/module.py
+++ b/modules/primary_monitoring/module.py
@@ -1,9 +1,17 @@
 """Contains code related to the Primary Monitoring module."""
 
+# standard
 import time
+import os
+import logging
+
+# local
 from modules.algorithm_module import AlgorithmModule
 # from resolve.enums import Function, Module
 # from modules.enums import PrimaryMonitoringEnums
+
+# global
+logger = logging.getLogger(__name__)
 
 
 class PrimaryMonitoringModule(AlgorithmModule):
@@ -15,6 +23,9 @@ class PrimaryMonitoringModule(AlgorithmModule):
 
     def run(self):
         """Called whenever the module is launched in a separate thread."""
+        sec = os.getenv("INTEGRATION_TEST_SLEEP")
+        time.sleep(int(sec) if sec is not None else 0)
+
         while True:
             time.sleep(1)
 

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -75,6 +75,9 @@ class ReplicationModule(AlgorithmModule):
 
     def run(self):
         """Called whenever the module is launched in a separate thread."""
+        sec = os.getenv("INTEGRATION_TEST_SLEEP")
+        time.sleep(int(sec) if sec is not None else 0)
+
         while True:
             # lines 1-3
             self.lock.acquire()

--- a/modules/view_establishment/module.py
+++ b/modules/view_establishment/module.py
@@ -61,6 +61,9 @@ class ViewEstablishmentModule(AlgorithmModule):
 
     def run(self):
         """Called whenever the module is launched in a separate thread."""
+        sec = os.getenv("INTEGRATION_TEST_SLEEP")
+        time.sleep(int(sec) if sec is not None else 0)
+
         while True:
             self.lock.acquire()
             if(self.pred_and_action.need_reset()):

--- a/scripts/test
+++ b/scripts/test
@@ -41,7 +41,7 @@ if [ $# -eq 0 ]; then
     run_unit_tests
     run_integration_tests
 elif [ $# -ge 1 ]; then
-    # if 2nd argument supplied, export ENV VAR with $2 seconds to sleep when starting modules
+    # if 2nd argument supplied, export env var INTEGRATION_TEST_SLEEP with $2 seconds to sleep when starting modules
     if [ $# -eq 2 ]; then
         export INTEGRATION_TEST_SLEEP=$2
     fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# run as ./test unit|it|pattern [time to sleep on module startup]
+
 export WERKZEUG_RUN_MAIN=true
 
 # kills script with failure code if last executed command was not successful
@@ -38,7 +40,12 @@ if [ $# -eq 0 ]; then
     # run all tests
     run_unit_tests
     run_integration_tests
-elif [ $# -eq 1 ]; then
+elif [ $# -ge 1 ]; then
+    # if 2nd argument supplied, export ENV VAR with $2 seconds to sleep when starting modules
+    if [ $# -eq 2 ]; then
+        export INTEGRATION_TEST_SLEEP=$2
+    fi
+
     # run either integration tests, unit tests or tests matching pattern $1
     if [ "$1" = "it" ]; then
         run_integration_tests


### PR DESCRIPTION
* Optional sleep parameter when using the `./scripts/test option [delay]` script. Will cause the nodes to initialize and start serving the API, but then wait for the specified time.

For example, running `./scripts/test it 5` would add a delay of 5 seconds for every integration test, making it possible to inspect starting state for all nodes on the `/view` endpoint for example.