### PR TITLE
3 Trello ticket bugs fixed

### DIFF
--- a/modules/replication/models/replica_structure.py
+++ b/modules/replication/models/replica_structure.py
@@ -12,7 +12,7 @@ from typing import List, Dict
 
 # local
 from modules.constants import (REQUEST, REPLY, STATUS, X_SET)
-from .request import Request
+from .request import Request, ClientRequest
 
 
 class ReplicaStructure():
@@ -73,7 +73,7 @@ class ReplicaStructure():
         """
         self.r_log = r_log
 
-    def get_pend_reqs(self) -> List[Request]:
+    def get_pend_reqs(self) -> List[ClientRequest]:
         """Returns the requests received from clients, all ClientRequests
 
         pend_reqs has size SIGMA * K, where SIGMA is a user-defined constant
@@ -81,16 +81,18 @@ class ReplicaStructure():
         """
         return self.pend_reqs
 
-    def extend_pend_reqs(self, req: Request):
+    def extend_pend_reqs(self, req: [ClientRequest]):
         """Adds a request to pend_reqs."""
-        self.pend_reqs.extend(req)
+        for r in req:
+            if r not in self.pend_reqs:
+                self.pend_reqs.add(r)
 
-    def remove_from_pend_reqs(self, req: Request):
+    def remove_from_pend_reqs(self, req: ClientRequest):
         """Removes the first occurrence of req from pend_reqs."""
         if req in self.pend_reqs:
             self.pend_reqs.remove(req)
 
-    def set_pend_reqs(self, pend_reqs: List[Request]):
+    def set_pend_reqs(self, pend_reqs: List[ClientRequest]):
         """Sets the pend_reqs for this processor."""
         self.pend_reqs = pend_reqs
 

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -123,8 +123,6 @@ class ReplicationModule(AlgorithmModule):
                     Function.NO_VIEW_CHANGE) and
                         self.rep[self.id].get_view_changed() is False):
                     if prim_id == self.id:
-                        # TODO https://bit.ly/2GAG5pc
-                        # for req in self.rep[self.id].get_pend_reqs():
                         for req in self.unassigned_reqs():
                             if self.rep[self.id].get_seq_num() < \
                                     (self.last_exec() +

--- a/tests/unit_tests/test_replication.py
+++ b/tests/unit_tests/test_replication.py
@@ -83,7 +83,7 @@ class TestReplicationModule(unittest.TestCase):
         # There is no executed requests
         replication.rep[replication.id].set_r_log([])
 
-        self.assertIsNone(replication.last_exec())
+        self.assertEqual(replication.last_exec(), -1)
         
 
     def test_last_common_execution(self):
@@ -398,15 +398,15 @@ class TestReplicationModule(unittest.TestCase):
         #         ]
         replication.rep = [ReplicaStructure(
             0,
-            pend_reqs=[self.dummyRequest1, self.dummyRequest2]
+            pend_reqs=[self.dummyRequest1.get_client_request(), self.dummyRequest2.get_client_request()]
         )] + [ReplicaStructure(
             i,
             req_q=[{REQUEST: self.dummyRequest1, STATUS:{}}]
         ) for i in range(1,4)] + [ReplicaStructure(
             i,
-            pend_reqs=[self.dummyRequest1]
+            pend_reqs=[self.dummyRequest1.get_client_request()]
         ) for i in range(4,6)]
-        self.assertEqual(replication.known_pend_reqs(), [self.dummyRequest1])
+        self.assertEqual(replication.known_pend_reqs(), [self.dummyRequest1.get_client_request()])
 
         # No known pending request found, only 3 processor has dummyRequest1
         # replication.rep = [{
@@ -1036,7 +1036,7 @@ class TestReplicationModule(unittest.TestCase):
         replication.stale_rep = MagicMock(return_value = False)
         replication.conflict = MagicMock(return_value = False)
         replication.last_exec = Mock()
-        replication.unassigned_reqs = Mock()
+        #replication.unassigned_reqs = Mock()
         replication.committed_set = MagicMock(return_value = [])
         replication.reqs_to_prep = Mock()
         replication.commit = Mock()
@@ -1236,7 +1236,7 @@ class TestReplicationModule(unittest.TestCase):
         replication.stale_rep = MagicMock(return_value = False)
         replication.conflict = MagicMock(return_value = False)
         replication.known_pend_reqs = Mock()
-        replication.unassigned_reqs = Mock()
+        
         replication.committed_set = MagicMock(reurn_value = [])
         replication.reqs_to_prep = Mock()
         replication.commit = Mock()
@@ -1251,6 +1251,7 @@ class TestReplicationModule(unittest.TestCase):
         replication.resolver.execute = MagicMock(side_effect = lambda y, func, x=-1 : self.get_0_as_view(func))
         replication.known_pend_reqs = MagicMock(return_value = [])
         replication.last_exec = MagicMock(return_value = 2)
+        #replication.unassigned_reqs = MagicMock(return_value=[])
         # replication.seq_n = 2
 
         # unassigned_req1 = {CLIENT_REQ: {CLIENT: 0}, VIEW: -1, SEQUENCE_NO: -1}


### PR DESCRIPTION
* When being new primary, update sequence number to max of last_exec() or the highest sequence number of request in req_q with BOTH status PRE_PREP and PREP

* When adding client request to pend_req, check so it doesn't already exists in the list

* When being prim and assigning PRE_PREP and PREP-message, only consider unassigned client requests