### PR TITLE
Feature/rep mod pre prep

### DIFF
--- a/modules/replication/models/client_request.py
+++ b/modules/replication/models/client_request.py
@@ -50,6 +50,10 @@ class ClientRequest:
                     self.operation == other.get_operation())
         return False
 
+    def __hash__(self):
+        """Overrides the default implementation"""
+        return hash((self.client_id, self.timestamp))
+
     def to_dct(self):
         """Converts a client request to a corresponding dictionary."""
         return {"client_id": self.client_id, "timestamp": self.timestamp,

--- a/modules/replication/models/replica_structure.py
+++ b/modules/replication/models/replica_structure.py
@@ -115,7 +115,7 @@ class ReplicaStructure():
         NOTE that no validation is done on the performed req_q. This is mainly
         used for testing purposes.
         """
-        self.req_q = req_q
+        self.req_q = deepcopy(req_q)
 
     def remove_from_req_q(self, req):
         """Removes all occurrences of req from req_q."""

--- a/modules/replication/models/request.py
+++ b/modules/replication/models/request.py
@@ -27,13 +27,17 @@ class Request:
         """Returns the view associated with this request."""
         return self.view
 
-    def set_view(self, view):
+    def set_view(self, view: int):
         """Updates the view of this request."""
         self.view = view
 
     def get_seq_num(self) -> int:
         """Returns the sequence number associated with this request."""
         return self.seq_num
+
+    def set_seq_num(self, seq_num: int):
+        """Returns the sequence number associated with this request."""
+        self.seq_num = seq_num
 
     def __eq__(self, other):
         """Overrides the default implementation."""

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -844,11 +844,11 @@ class ReplicationModule(AlgorithmModule):
                 state = op.execute(state)
             if state == prefix_state:
                 # found correct r_log entries
-                r_log = entries
-                return
+                # entries is tuple -> convert to list
+                r_log = list(entries)
+                break
         if r_log == []:
             return (-1, [])
-
         return (prefix_state, r_log)
 
     def find_prefix(self, rep_states: List):

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -851,6 +851,7 @@ class ReplicationModule(AlgorithmModule):
         # assume no duplicate requests in pendReqs
         seen_reqs = {k: v for (k, v) in seen_reqs.items()
                      if v == len(processors_set)}
+        print(seen_reqs.keys())
         self.rep[self.id].set_pend_reqs(list(seen_reqs.keys()))
 
         # find all reqs that only have pre-prep message, need to create new
@@ -897,13 +898,6 @@ class ReplicationModule(AlgorithmModule):
         r_log entry at this processor.
         NOTE that returning (-1, *) means that something went wrong.
         """
-        # if len(processors_set) == 0:
-        #     return (-1, [])
-
-        # rep_states = []
-        # for processor_id in processors_set:
-        #     rep_states.append(self.rep[processor_id].get_rep_state())
-
         if len(processors_states) == 0:
             return (-1, [])
 

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -11,8 +11,8 @@ from typing import List, Tuple
 # local
 from modules.algorithm_module import AlgorithmModule
 from modules.enums import ReplicationEnums, OperationEnums
-from modules.constants import (MAXINT, SIGMA, X_SET, REP_STATE, CLIENT_REQ,
-                               REQUEST, STATUS, SEQUENCE_NO)
+from modules.constants import (MAXINT, SIGMA, X_SET, REP_STATE,
+                               REQUEST, STATUS)
 from resolve.enums import Module, Function, MessageType
 import conf.config as conf
 from .models.replica_structure import ReplicaStructure
@@ -961,10 +961,7 @@ class ReplicationModule(AlgorithmModule):
                 replica_structure.get_req_q())
             )
             for req_pair in pre_prep_reqs:
-                key = {
-                    CLIENT_REQ: req_pair[REQUEST].get_client_request(),
-                    SEQUENCE_NO: req_pair[REQUEST].get_seq_num()
-                }
+                key = req_pair[REQUEST].get_client_request()
                 if key in req_exists_count:
                     req_exists_count[key] += 1
                 else:
@@ -974,17 +971,15 @@ class ReplicationModule(AlgorithmModule):
         # for 3f + 1 processors
         for req_pair in self.rep[prim].get_req_q():
             if req_pair[REQUEST].get_view() == prim:
-                key = {
-                    CLIENT_REQ: req_pair[REQUEST].get_client_request(),
-                    SEQUENCE_NO: req_pair[REQUEST].get_seq_num()
-                }
+                key = req_pair[REQUEST].get_client_request()
                 # add dummy requests to req_q to avoid halting
-                if key.get_client_request().is_dummy():
-                    dummy_seq_num = key.get_seq_num()
+                if key.is_dummy():
+                    dummy_seq_num = req_pair[REQUEST].get_seq_num()
                     # make sure dummy seq num does not exist for other req
                     # in req q
                     for r in self.rep[prim].get_req_q():
-                        if r != key and r.get_seq_num() == dummy_seq_num:
+                        if (r[REQUEST].get_client_request() != key and
+                           r[REQUEST].get_seq_num() == dummy_seq_num):
                             return False
 
                     continue

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -735,9 +735,8 @@ class ReplicationModule(AlgorithmModule):
             # then add last executed sequence number
             new_seq = max(self.last_exec(), potential_seq)
             self.rep[self.id].set_seq_num(new_seq)
-
             last_seq_num = self.last_exec()
-            if new_seq > last_seq_num:
+            while new_seq > last_seq_num:
                 # check if missing requests are in request queue
                 last_seq_num += 1
                 if not self.req_with_seq_num_in_req_q(last_seq_num):

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -837,7 +837,7 @@ class ReplicationModule(AlgorithmModule):
         """Method description.
 
         Creates PRE_PREP msg for each request not being executed by
-        4f+1 processors.
+        the processors in processor_set.
         """
         # remove requests that does not exist for all
         # processors in processors_set
@@ -856,16 +856,16 @@ class ReplicationModule(AlgorithmModule):
 
         # find all reqs that only have pre-prep message, need to create new
         reqs_need_pre_prep = list(filter(
-            lambda r: r[STATUS] == {ReplicationEnums.PRE_PREP}),
-            self.rep[self.id].get_req_q()
+            lambda r: r[STATUS] == {ReplicationEnums.PRE_PREP},
+            self.rep[self.id].get_req_q())
         )
 
         for j in processors_set:
             j_req_q = self.rep[j].get_req_q()
             j_reqs_need_pre_prep = list(filter(
                 lambda r: (r[STATUS] == {ReplicationEnums.PRE_PREP} and
-                           r in reqs_need_pre_prep)),
-                j_req_q)
+                           r in reqs_need_pre_prep),
+                j_req_q))
 
             # filter out all pre_prep reqs that are not in j's req q
             reqs_need_pre_prep = list(filter(
@@ -877,6 +877,7 @@ class ReplicationModule(AlgorithmModule):
             if req in reqs_need_pre_prep:
                 # current view is equal to self.id since we are primary
                 req[REQUEST].set_view(self.id)
+
                 # Increment sequence number and assign
                 self.rep[self.id].inc_seq_num()
                 req[REQUEST].set_seq_num(self.rep[self.id].get_seq_num())

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -930,7 +930,7 @@ class ReplicationModule(AlgorithmModule):
                     seen_reqs[req] < (3 * self.number_of_byzantine + 1)):
                 return False
 
-        return self.check_new_v_state(prim)
+        return self.check_new_state_and_r_log(prim)
 
     def check_new_state_and_r_log(self, prim) -> bool:
         """Checks the state and r_log proposed by the new primary."""

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -375,8 +375,8 @@ class ReplicationModule(AlgorithmModule):
                     break
             # All replica states where prefixes to each other
             if(all_states_are_prefixes):
-                return S
-        return set()
+                return list(S)
+        return []
 
     def get_ds_state(self) -> Tuple[List, List]:
         """Method description.
@@ -885,10 +885,10 @@ class ReplicationModule(AlgorithmModule):
                 # PRE_PREP - message
                 req[STATUS].add(ReplicationEnums.PREP)
 
-    def find_cons_state(self, processors_set) -> Tuple[List, List]:
+    def find_cons_state(self, processors_states) -> Tuple[List, List]:
         """Method description.
 
-        Returns a consolidated replica state based on the processors_set,
+        Returns a consolidated replica state based on the processors_states,
         the set should have a common (non-empty) prefix and consistency
         among request and pending queues.
         Produces a dummy request if 3f+1 processor have committed a number
@@ -898,14 +898,17 @@ class ReplicationModule(AlgorithmModule):
         r_log entry at this processor.
         NOTE that returning (-1, *) means that something went wrong.
         """
-        if len(processors_set) == 0:
+        # if len(processors_set) == 0:
+        #     return (-1, [])
+
+        # rep_states = []
+        # for processor_id in processors_set:
+        #     rep_states.append(self.rep[processor_id].get_rep_state())
+
+        if len(processors_states) == 0:
             return (-1, [])
 
-        rep_states = []
-        for processor_id in processors_set:
-            rep_states.append(self.rep[processor_id].get_rep_state())
-
-        prefix_state = self.find_prefix(rep_states)
+        prefix_state = self.find_prefix(processors_states)
         if prefix_state == []:
             return (-1, [])
 

--- a/tests/unit_tests/test_replication.py
+++ b/tests/unit_tests/test_replication.py
@@ -1775,8 +1775,6 @@ class TestReplicationModule(unittest.TestCase):
         # Half of the nodes are in the set so it's less than 4f+1,
         #  methods should not be called and view_change = True
         replication.act_as_prim_when_view_changed(0)
-
-        self.maxDiff = None
         self.assertEqual(replication.rep[replication.id].get_req_q(),
         [
             {REQUEST: self.dummyRequest1, STATUS: {ReplicationEnums.PRE_PREP, ReplicationEnums.PREP}},

--- a/tests/unit_tests/test_replication.py
+++ b/tests/unit_tests/test_replication.py
@@ -1229,3 +1229,152 @@ class TestReplicationModule(unittest.TestCase):
             return True
         else:
             return 0
+
+    # Added functions after implementing find_cons_state
+
+    def test_is_prefix_of(self):
+        replication = ReplicationModule(0, Resolver(), 2, 0, 1)
+
+        # Basic examples
+        log_A = [1,2,3]
+        log_B = [1,2]
+        self.assertFalse(replication.is_prefix_of(log_A, log_B))
+        self.assertTrue(replication.is_prefix_of(log_B, log_A))
+
+        log_B = [1,2,5]
+        self.assertFalse(replication.is_prefix_of(log_B, log_A))
+        
+        log_A = []
+        self.assertTrue(replication.is_prefix_of(log_A, log_B))
+
+        # Examples with dcts
+        log_A = [{REQUEST: self.dummyRequest1, X_SET:{2}}]
+        log_B = [{REQUEST: self.dummyRequest1, X_SET:{2}}, 
+                {REQUEST: self.dummyRequest2, X_SET:{1,3}}, 
+                ]
+        self.assertTrue(replication.is_prefix_of(log_A, log_B))
+        self.assertFalse(replication.is_prefix_of(log_B, log_A))
+        
+        log_A = [{REQUEST: self.dummyRequest1, X_SET:{2,4}}]
+        log_B = [{REQUEST: self.dummyRequest1, X_SET:{2}}, 
+                {REQUEST: self.dummyRequest2, X_SET:{1,3}}, 
+                ]
+        self.assertFalse(replication.is_prefix_of(log_A, log_B))
+
+    def test_find_prefix(self):
+        replication = ReplicationModule(0, Resolver(), 2, 0, 1)
+
+        # Basic examples
+        log_A = [1,2,3]
+        log_B = [1,2]
+        self.assertEqual(replication.find_prefix([log_A, log_B]), [1,2])
+        self.assertEqual(replication.find_prefix([log_B, log_A]), [1,2])
+
+        log_B = [1,2,5]
+        self.assertEqual(replication.find_prefix([log_B, log_A]), [1,2])
+        
+        log_A = []
+        self.assertEqual(replication.find_prefix([log_A, log_B]), [])
+
+        log_A = [2,5]
+        self.assertEqual(replication.find_prefix([log_A, log_B]), [])
+
+    def test_produce_dummy_req(self):
+        replication = ReplicationModule(0, Resolver(), 6, 1, 1)
+        target_request = Request(
+            ClientRequest(-1, None, Operation(
+                OperationEnums.NO_OP
+            )),
+            0,
+            2)
+        self.assertEqual(replication.produce_dummy_req(2),
+            {
+            REQUEST: target_request,
+            STATUS: {ReplicationEnums.PRE_PREP, ReplicationEnums.PRE_PREP}
+            })
+
+    def test_req_with_seq_num_in_req_q(self):
+        replication = ReplicationModule(0, Resolver(), 6, 1, 1)
+        replication.rep[replication.id].set_req_q([
+            {REQUEST: self.dummyRequest1,
+            STATUS: {ReplicationEnums.PRE_PREP}
+            }])
+        self.assertTrue(replication.req_with_seq_num_in_req_q(1))
+        self.assertFalse(replication.req_with_seq_num_in_req_q(2))
+
+    def test_check_new_state_and_r_log(self):
+        replication = ReplicationModule(0, Resolver(), 6, 1, 1)
+        # Let prim == 1
+
+        replication.rep = [ReplicaStructure(
+            i,
+            rep_state = [1,2,3],
+            r_log = [],
+            prim=1
+        ) for i in range(6)]
+
+        # Change replica structure of primary
+        prim_r_log = [
+            {REQUEST: self.dummyRequest1, REPLY: [1]},
+            {REQUEST: self.dummyRequest2, REPLY: [1,2]}]
+
+        replication.rep[1].set_rep_state([1,2])
+        replication.rep[1].set_r_log(prim_r_log)
+        self.assertTrue(replication.check_new_state_and_r_log(1))
+
+        # Now the r_log does not comply with the given new state
+        prim_r_log = [
+            {REQUEST: self.dummyRequest1, REPLY: [1]},
+            {REQUEST: self.dummyRequest1, REPLY: [1,1]}]
+        replication.rep[1].set_r_log(prim_r_log)
+        self.assertFalse(replication.check_new_state_and_r_log(1))
+
+        # The replica state of the primary is not a prefix of the others
+        replication.rep[1].set_rep_state([1,4])
+        self.assertFalse(replication.check_new_state_and_r_log(1))
+
+    def test_find_cons_state(self):
+        replication = ReplicationModule(0, Resolver(), 6, 1, 1)
+        # Let prim == 1
+        r_log_entries = [
+            {REQUEST: self.dummyRequest1, REPLY: [1]},
+            {REQUEST: self.dummyRequest2, REPLY: [1,2]}]
+
+        # all replicas has the same state and r_log
+        replication.rep = [ReplicaStructure(
+            i,
+            rep_state = [1,2],
+            r_log = r_log_entries,
+            prim=1
+        ) for i in range(6)]
+
+        target = ([1,2], r_log_entries)
+        self.assertEqual(replication.find_cons_state({0,1,2,3,4,5}), target)
+
+        # Empty set should return "TEE"
+        self.assertEqual(replication.find_cons_state(set()), (-1, []))
+
+        # Empty prefix_state should return "TEE"
+        # Nodes don't have a prefix in common
+        replication.rep = [ReplicaStructure(
+            i,
+            rep_state = [1,2],
+            r_log = r_log_entries,
+            prim=1
+        ) for i in range(3)] + [ReplicaStructure(
+            i,
+            rep_state = [2,4],
+            r_log = r_log_entries,
+            prim=1
+        ) for i in range(3,6)]
+        self.assertEqual(replication.find_cons_state({0,1,2,3,4,5}), (-1, []))
+
+        # Empty R_log should return "TEE"
+        # Their r_log does not match the common prefix
+        self.assertEqual(replication.find_cons_state({0,1,2,3,4,5}), (-1, []))        
+        replication.rep = [ReplicaStructure(
+            i,
+            rep_state = [1,2],
+            r_log = [{REQUEST: self.dummyRequest1, REPLY: [1]}],
+            prim=1
+        ) for i in range(6)]


### PR DESCRIPTION
* Unit tests for:

- find_prefix
- is_prefix_of
- produce_dummy_req
- req_with_seq_num_in_req_q
- check_new_state_and_r_log
- test_find_cons_state
- added logic in run-method
- renew_reqs
- check_new_v_state
- act_as_prim_when_view_changed

* Hash function for client_request (in order to have them as keys in dct)
* Change input type for find_cons_state, now takes a list of rep_states and does the same thing as before
* set_seq_num function in Request added
* added new logic for pre_prep and prep according to email, includes new help functions

I'm gonna get you a premium coffee after you reviewed this MASSIVE pr.