### PR TITLE
Testing/it prim mon case 4

### DIFF
--- a/api/templates/view/scripts.html
+++ b/api/templates/view/scripts.html
@@ -97,7 +97,7 @@
             cur_check_req = 'Current request: '
     
         data.need_chg_set.forEach(i => {
-            need_chg_set += '[${r}]'
+            need_chg_set += `[${i}]`
         })
         if (data.need_chg_set.length == 0) need_chg_set += '[]'
 

--- a/modules/constants.py
+++ b/modules/constants.py
@@ -36,4 +36,4 @@ V_STATUS = "v_status"
 NEED_CHANGE = "need_change"
 NEED_CHG_SET = "need_chg_set"
 
-THRESHOLD = 100  # Threshold for liveness, beat-variable
+THRESHOLD = 10  # Threshold for liveness, beat-variable

--- a/modules/primary_monitoring/failure_detector.py
+++ b/modules/primary_monitoring/failure_detector.py
@@ -123,7 +123,6 @@ class FailureDetectorModule:
                self.prim_susp[processor_id]):
                 num_of_processor += 1
         if num_of_processor >= (3 * self.number_of_byzantine + 1):
-            logger.info("Returning suspected primary")
             return True
         return False
 

--- a/modules/primary_monitoring/failure_detector.py
+++ b/modules/primary_monitoring/failure_detector.py
@@ -11,6 +11,7 @@ from resolve.enums import Function, Module
 from modules.constants import THRESHOLD, VIEW_CHANGE
 from resolve.enums import MessageType
 from queue import Queue
+import conf.config as conf
 
 # globals
 logger = logging.getLogger(__name__)
@@ -20,6 +21,7 @@ class FailureDetectorModule:
     """Models the Primary Monitoring moduel - Failure detector algorithm."""
 
     run_forever = True
+    first_run = True
 
     def __init__(self, id, resolver, n, f):
         """Initializes the module."""
@@ -35,10 +37,26 @@ class FailureDetectorModule:
         self.prim = -1
         self.msg_queue = Queue()
 
+        if os.getenv("INTEGRATION_TEST"):
+            start_state = conf.get_start_state()
+            if (start_state is not {} and str(self.id) in start_state and
+               "FAILURE_DETECTOR_MODULE" in start_state[str(self.id)]):
+                data = start_state[str(self.id)]["FAILURE_DETECTOR_MODULE"]
+                if data is not None:
+                    if "beat" in data:
+                        self.beat = deepcopy(data["beat"])
+                    if "cnt" in data:
+                        self.cnt = deepcopy(data["cnt"])
+                    if "prim_susp" in data:
+                        self.prim_susp = deepcopy(data["prim_susp"])
+                    if "cur_check_req" in data:
+                        self.cur_check_req = deepcopy(data["cur_check_req"])
+                    if "prim" in data:
+                        self.prim = deepcopy(data["prim"])
+
     def run(self):
         """Called whenever the module is launched in a separate thread."""
         while True:
-
             if self.msg_queue.empty():
                 time.sleep(0.1)
             else:
@@ -48,8 +66,14 @@ class FailureDetectorModule:
                 self.upon_token_from_pj(processor_j, prim_susp_j)
                 self.send_msg(processor_j)
 
-            if(not self.run_forever):
+            if not self.run_forever:
                 break
+
+            if self.first_run:
+                nodes = conf.get_nodes()
+                for node_j, _ in nodes.items():
+                    self.send_msg(node_j)
+                self.first_run = False
 
             time.sleep(0.1 if os.getenv("INTEGRATION_TEST") else 0.25)
 
@@ -99,6 +123,7 @@ class FailureDetectorModule:
                self.prim_susp[processor_id]):
                 num_of_processor += 1
         if num_of_processor >= (3 * self.number_of_byzantine + 1):
+            logger.info("Returning suspected primary")
             return True
         return False
 

--- a/modules/primary_monitoring/failure_detector.py
+++ b/modules/primary_monitoring/failure_detector.py
@@ -72,7 +72,8 @@ class FailureDetectorModule:
             if self.first_run:
                 nodes = conf.get_nodes()
                 for node_j, _ in nodes.items():
-                    self.send_msg(node_j)
+                    if node_j != self.id:
+                        self.send_msg(node_j)
                 self.first_run = False
 
             time.sleep(0.1 if os.getenv("INTEGRATION_TEST") else 0.25)

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -965,9 +965,10 @@ class ReplicationModule(AlgorithmModule):
         of other processors.
         """
         if not self.rep[self.id].get_view_changed():
-            intersection_set = set(self.known_pend_reqs()).intersection(set(self.unassigned_reqs()))
+            intersection_set = set(self.known_pend_reqs()).intersection(
+                                            set(self.unassigned_reqs()))
             return(list(intersection_set))
-            #return(self.known_pend_reqs().intersection(self.unassigned_reqs()))
+            # return(self.known_pend_reqs().intersection(self.unassigned_reqs()))
         else:
             return(VIEW_CHANGE)
 

--- a/modules/replication/module.py
+++ b/modules/replication/module.py
@@ -965,7 +965,9 @@ class ReplicationModule(AlgorithmModule):
         of other processors.
         """
         if not self.rep[self.id].get_view_changed():
-            return(self.known_pend_reqs().intersection(self.unassigned_reqs()))
+            intersection_set = set(self.known_pend_reqs()).intersection(set(self.unassigned_reqs()))
+            return(list(intersection_set))
+            #return(self.known_pend_reqs().intersection(self.unassigned_reqs()))
         else:
             return(VIEW_CHANGE)
 

--- a/tests/integration_tests/test_primary_monitoring_demand_view_change.py
+++ b/tests/integration_tests/test_primary_monitoring_demand_view_change.py
@@ -1,0 +1,123 @@
+"""
+Case 4 (Primary monitoring)
+The systems starts in a safe state but the primary is acting Byzantine and
+stops assigning seqnums/stops propagating requests. 
+
+Primary Monitoring should detect and demand a view change of the View Establishment 
+Module. After the view is established (new primary is Node 1), the client request
+should be assigned sequence numbers and applied.
+"""
+
+# standard
+import asyncio
+import logging
+from copy import deepcopy
+
+# local
+from . import helpers
+from .abstract_integration_test import AbstractIntegrationTest
+from modules.replication.models.replica_structure import ReplicaStructure
+from modules.replication.models.client_request import ClientRequest
+from modules.replication.models.request import Request
+from modules.replication.models.operation import Operation
+from modules.constants import REQUEST, STATUS, MAXINT, SIGMA, X_SET, REPLY
+from modules.enums import ReplicationEnums as enums
+
+# globals
+F = 1
+N = 6
+logger = logging.getLogger(__name__)
+start_state = {}
+
+client_req_1 = ClientRequest(0, 0, Operation("APPEND", 1))
+
+for i in range(N):
+    start_state[str(i)] = {
+        # force stable view_pair for all nodes
+        "VIEW_ESTABLISHMENT_MODULE": {
+            "views": [{"current": 0, "next": 0} for i in range(N)]
+        },
+        "REPLICATION_MODULE": {
+            "rep": [
+                ReplicaStructure(
+                    j,
+                    pend_reqs=[client_req_1],
+                    prim = 0
+                ) for j in range(N)
+            ]
+        },
+        "PRIMARY_MONITORING_MODULE": {
+            "prim": 0
+        },
+        "FAILURE_DETECTOR_MODULE": {
+            "prim": 0,
+            "cur_check_req":[client_req_1]
+        }
+    }
+
+args = {
+    "BYZANTINE": {
+        "NODES": [0],
+        "BEHAVIOR": "STOP_ASSIGNING_SEQNUMS"
+    }
+}
+
+class TestByzStopsAssigningSeqNum(AbstractIntegrationTest):
+    """Checks that a Byzantine node can not trick some nodes to do a view change."""
+
+    async def bootstrap(self):
+        """Sets up BFTList for the test."""
+        helpers.write_state_conf_file(start_state)
+        return await helpers.launch_bftlist(__name__, args)
+
+    async def validate(self):
+        calls_left = helpers.MAX_NODE_CALLS
+        test_result = False
+
+        await asyncio.sleep(30)
+
+        while calls_left > 0:
+            aws = [helpers.GET(i, "/data") for i in helpers.get_nodes()]
+            checks = []
+            last_check = calls_left == 1
+
+            for a in asyncio.as_completed(aws):
+                result = await a
+                data = result["data"]["REPLICATION_MODULE"]
+                id = data["id"]
+
+                if last_check:
+                    self.assertEqual(data["rep_state"], [1])
+                    self.assertEqual(len(data["r_log"]), 1)
+                    self.assertEqual(len(data["pend_reqs"]), 2)                    
+                else:
+                    checks.append(data["rep_state"] == [1])
+                    checks.append(len(data["r_log"]) == 1)
+                    checks.append(len(data["pend_reqs"]) == 2)
+
+            # if all checks passed, test passed
+            if all(checks):
+                test_result = True
+                break
+
+            # sleep for 2 seconds and re-try
+            await asyncio.sleep(2)
+            calls_left -= 1
+
+        self.assertTrue(test_result)
+
+    @helpers.suppress_warnings
+    def test(self):
+        logger.info(f"{__name__} starting")
+        pids = helpers.run_coro(self.bootstrap())
+        super().set_pids(pids)
+
+        helpers.run_coro(self.validate())
+        logger.info(f"{__name__} finished")
+
+    def tearDown(self):
+        helpers.kill(super().get_pids())
+        helpers.cleanup()
+
+if __name__ == '__main__':
+    asyncio.run(unittest.main())

--- a/tests/integration_tests/test_primary_monitoring_demand_view_change.py
+++ b/tests/integration_tests/test_primary_monitoring_demand_view_change.py
@@ -89,11 +89,11 @@ class TestByzStopsAssigningSeqNum(AbstractIntegrationTest):
                 if last_check:
                     self.assertEqual(data["rep_state"], [1])
                     self.assertEqual(len(data["r_log"]), 1)
-                    self.assertEqual(len(data["pend_reqs"]), 2)                    
+                    self.assertEqual(len(data["pend_reqs"]), 0)                    
                 else:
                     checks.append(data["rep_state"] == [1])
                     checks.append(len(data["r_log"]) == 1)
-                    checks.append(len(data["pend_reqs"]) == 2)
+                    checks.append(len(data["pend_reqs"]) == 0)
 
             # if all checks passed, test passed
             if all(checks):

--- a/tests/unit_tests/test_replication.py
+++ b/tests/unit_tests/test_replication.py
@@ -473,7 +473,7 @@ class TestReplicationModule(unittest.TestCase):
         replication.unassigned_reqs = MagicMock(return_value = {1,2})
         replication.known_pend_reqs = MagicMock(return_value = {2,3})
         replication.view_changed = False
-        self.assertEqual(replication.get_pend_reqs(), {2})
+        self.assertEqual(replication.get_pend_reqs(), [2])
 
     def test_rep_request_reset(self):
         replication = ReplicationModule(0, Resolver(), 2, 0, 1)


### PR DESCRIPTION
* In Replication module interface get_pend_reqs, convert to set and then back to list, is apparently faster than using list comprehension.

* IT case 4 of Primary Montoring implemented and passes.

* Added support for injecting starting configuration for primary monitoring/failure detector